### PR TITLE
guard against FilterLimitExceeded for large number of keypairs

### DIFF
--- a/lambda/ec2.py
+++ b/lambda/ec2.py
@@ -57,6 +57,19 @@ def describe_instances(**kwargs):
             for instance in reservation['Instances']:
                 yield instance
 
+def get_instances_with_key_names(key_names):
+    """
+    Describes one or more of your instances whose 'key-name' value matches any item in key_names.
+
+    """
+    return describe_instances(
+        Filters=[
+            {
+                'Name': 'key-name',
+                'Values': key_names,
+            }
+        ]
+    )
 
 def describe_key_pairs(**kwargs):
     """

--- a/lambda/ec2.py
+++ b/lambda/ec2.py
@@ -57,7 +57,7 @@ def describe_instances(**kwargs):
             for instance in reservation['Instances']:
                 yield instance
 
-def get_instances_with_key_names(key_names):
+def describe_instances_with_key_names(key_names):
     """
     Describes one or more of your instances whose 'key-name' value matches any item in key_names.
 


### PR DESCRIPTION
When running against a region with over 200 keypairs, the script fails with:

> Traceback (most recent call last):
  File "lambda/packer.py", line 116, in <module>
    cleanup()
  File "lambda/packer.py", line 29, in cleanup
    for key_name in get_old_packer_keys():
  File "lambda/packer.py", line 94, in get_old_packer_keys
    for instance in instances:
  ...
botocore.exceptions.ClientError: An error occurred (FilterLimitExceeded) when calling the DescribeInstances operation: The maximum number of filter values specified on a single call is 200

This splits the list of `packer_keys` and calls `ec2#describe_instances` on each such that we avoid the limit on filter values. 